### PR TITLE
styling. module box styling

### DIFF
--- a/css/electrode.scss
+++ b/css/electrode.scss
@@ -557,7 +557,7 @@ img.mob-menu {
   border-bottom: 1px solid #cccccc;
 }
 
-.electrode-modules, #modules-section {
+.electrode-modules {
   font-family: "Gotham-Rounded";
   text-align: center;
 
@@ -587,12 +587,16 @@ img.mob-menu {
       font-family: "Gotham-Rounded-Medium";
     }
 
+    .desktop-module-logo {
+      margin-top: 40px;
+      right: 60px;
+      text-align: right;
+      padding: 0;
+    }
+
     .desktop-module-logo img {
       width: 66px;
-      float: right;
       height: 75px;
-      margin-right: 20px;
-
     }
 
     .desktop-module-text {
@@ -650,49 +654,133 @@ img.mob-menu {
 }
 
 @media (min-width: 768px) {
-  .desktop-module-item.module-row-1 {
-    .module-testbox {
-      min-height: 410px;
+  .electrode-modules {
+    .module-textbox {
+      padding-right: 30px;
     }
-  }
 
-  .desktop-module-item.module-row-2 {
-    .module-testbox {
-      min-height: 313px;
+    .desktop-module-item.module-row-1 {
+      .module-testbox {
+        min-height: 410px;
+      }
     }
-  }
 
-  .desktop-module-item.module-row-3 {
-    .module-testbox {
-      min-height: 213px;
+    .desktop-module-item.module-row-2 {
+      .module-testbox {
+        min-height: 400px;
+      }
+    }
+
+    .desktop-module-item.module-row-3 {
+      .module-testbox {
+        min-height: 303px;
+      }
+    }
+
+    .desktop-module-item {
+      .desktop-module-logo {
+        position: relative;
+        text-align: center;
+        width: 100%;
+        right: auto;
+      }
     }
   }
 }
 
 @media (min-width: 992px) {
-  .desktop-module-item.module-row-1 {
-    .module-testbox {
-      min-height: 190px;
-    }
-  }
+  .electrode-modules {
+    .desktop-module-item.module-row-1 {
+      .module-testbox {
+        min-height: 263px;
+      }
 
-  .desktop-module-item.module-row-2 {
-    .module-testbox {
-      min-height: 263px;
-    }
-  }
+      .module-column-left {
+        .desktop-module-logo {
+          right: 50px;
+        }
+      }
 
-  .desktop-module-item.module-row-3 {
-    .module-testbox {
-      min-height: 190px;
+      .module-column-right {
+        .desktop-module-logo {
+          right: 30px;
+        }
+      }
+
+      .desktop-module-logo {
+        position: absolute;
+        margin-top: 94px;
+        text-align: right;
+      }
+    }
+
+    .desktop-module-item.module-row-2 {
+      .module-testbox {
+        min-height: 263px;
+      }
+
+      .module-column-left {
+        .desktop-module-logo {
+          right: 50px;
+        }
+      }
+
+      .module-column-right {
+        .desktop-module-logo {
+          right: 30px;
+        }
+      }
+
+      .desktop-module-logo {
+        position: absolute;
+        margin-top: 94px;
+        text-align: right;
+      }
+    }
+
+    .desktop-module-item.module-row-3 {
+      .module-testbox {
+        min-height: 188px;
+      }
+
+      .module-column-left {
+        .desktop-module-logo {
+          right: 50px;
+        }
+      }
+
+      .module-column-right {
+        .desktop-module-logo {
+          right: 30px;
+        }
+      }
+
+      .desktop-module-logo {
+        position: absolute;
+        margin-top: 57px;
+        text-align: right;
+      }
     }
   }
 }
 
 @media (min-width: 1200px) {
-  .desktop-module-item.module-row-1 {
-    .module-testbox {
-      min-height: 263px;
+  .electrode-modules {
+    .desktop-module-item.module-row-1 {
+      .module-testbox {
+        min-height: 263px;
+      }
+
+      .module-testbox.module-column-right {
+        .desktop-module-logo {
+          right: 40px;
+        }
+      }
+
+      .desktop-module-logo {
+        position: absolute;
+        margin-top: 95px;
+      }
     }
   }
 
@@ -700,11 +788,32 @@ img.mob-menu {
     .module-testbox {
       min-height: 190px;
     }
+
+    .module-column-right {
+      .desktop-module-logo {
+        right: 40px;
+      }
+    }
+
+    .desktop-module-logo {
+      margin-top: 60px;
+      position: absolute;
+    }
   }
 
   .desktop-module-item.module-row-3 {
     .module-testbox {
-      min-height: 190px;
+      min-height: 163px;
+    }
+
+    .module-column-right {
+      .desktop-module-logo {
+        right: 40px;
+      }
+    }
+
+    .desktop-module-logo {
+      position: absolute;
     }
   }
 }
@@ -1491,10 +1600,6 @@ img.footer-sub-logo {
 .module-subheader {
   margin-top: 20px;
   margin-bottom: -20px;
-}
-
-.desktop-module-logo {
-  margin-top: 20px;
 }
 
 .module-textbox {

--- a/css/electrode.scss
+++ b/css/electrode.scss
@@ -553,7 +553,7 @@ img.mob-menu {
 }
 
 #modules-section {
-  padding: 20px 60px 80px 100px;
+  padding: 20px 0 80px 20px;
   border-bottom: 1px solid #cccccc;
 }
 
@@ -595,13 +595,20 @@ img.mob-menu {
 
     }
 
+    .desktop-module-text {
+      padding-right: 0;
+    }
     .module-testbox {
       font-size: 18px;
-      min-height: 240px;
-      padding-left: 30px;
-      margin-right: 40px;
+      padding-left: 20px;
       margin-top: 0px;
     }
+
+    .module-column-right {
+      margin-left: 5px;
+      margin-right: 0;
+    }
+
   }
 
   .electrode-modules-list {
@@ -642,46 +649,62 @@ img.mob-menu {
   }
 }
 
-@media (max-width: 1548px) {
-  .electrode-modules, #modules-section {
-    .desktop-module-item {
-      .module-testbox {
-        min-height: 270px;
-      }
+@media (min-width: 768px) {
+  .desktop-module-item.module-row-1 {
+    .module-testbox {
+      min-height: 410px;
+    }
+  }
+
+  .desktop-module-item.module-row-2 {
+    .module-testbox {
+      min-height: 313px;
+    }
+  }
+
+  .desktop-module-item.module-row-3 {
+    .module-testbox {
+      min-height: 213px;
     }
   }
 }
 
-@media (max-width: 1351px) {
-  #modules-section {
-    padding: 20px 0 80px 40px;
+@media (min-width: 992px) {
+  .desktop-module-item.module-row-1 {
+    .module-testbox {
+      min-height: 190px;
+    }
   }
 
-  .electrode-modules, #modules-section {
-    .desktop-module-item {
-      .module-testbox {
-        min-height: 340px;
-      }
+  .desktop-module-item.module-row-2 {
+    .module-testbox {
+      min-height: 263px;
+    }
+  }
+
+  .desktop-module-item.module-row-3 {
+    .module-testbox {
+      min-height: 190px;
     }
   }
 }
 
-@media (max-width: 1000px) {
-  .electrode-modules, #modules-section {
-    .desktop-module-item {
-      .module-testbox {
-        min-height: 420px;
-      }
+@media (min-width: 1200px) {
+  .desktop-module-item.module-row-1 {
+    .module-testbox {
+      min-height: 263px;
     }
   }
-}
 
-@media (max-width: 900px) {
-  .electrode-modules, #modules-section {
-    .desktop-module-item {
-      .module-testbox {
-        min-height: 500px;
-      }
+  .desktop-module-item.module-row-2 {
+    .module-testbox {
+      min-height: 190px;
+    }
+  }
+
+  .desktop-module-item.module-row-3 {
+    .module-testbox {
+      min-height: 190px;
     }
   }
 }
@@ -1452,10 +1475,6 @@ img.footer-sub-logo {
   margin-bottom: 20px;
   border: 1px solid #cccccc;
   border-radius: 4px;
-}
-
-.desktop-module-text {
-  margin: 20px -50px 20px 50;
 }
 
 #module-icon {

--- a/index.html
+++ b/index.html
@@ -430,10 +430,10 @@
             <h3>Supercharge your app, with or without Electrode Core</h3>
           </div>
 
-          <div class="row desktop-module-item">
+          <div class="row desktop-module-item module-row-1">
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-left">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>Above-the-Fold Rendering</b>
                   </div>
@@ -450,8 +450,8 @@
             </div>
 
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-right">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>Redux Router Engine</b>
                   </div>
@@ -468,10 +468,10 @@
             </div>
           </div>
 
-          <div class="row desktop-module-item">
+          <div class="row desktop-module-item module-row-2">
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-left">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>Confippet</b>
                   </div>
@@ -489,8 +489,8 @@
             </div>
 
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-right">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>SSR Profiling & Caching</b>
                   </div>
@@ -507,10 +507,10 @@
           </div>
         </div>
 
-          <div class="row desktop-module-item">
+          <div class="row desktop-module-item module-row-3">
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-left">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>Stateless CSRF Validation</b>
                   </div>
@@ -527,8 +527,8 @@
             </div>
 
             <div class="module-box">
-              <div class="col-sm-6 col-md-6 desktop-module-text">
-                <div class="row module-testbox">
+              <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
+                <div class="row module-testbox module-column-right">
                   <div class="col-sm-12 col-md-12 module-subheader">
                     <b>More Modules Coming Soon!</b>
                   </div>

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
 
 	<!-- begin electrode newest version modules -->
 
-    <div id="modules-section" class="container">
+    <div id="modules-section" class="electrode-modules container">
       <div class="container-fluid">
         <div id="desktop-modules-content">
           <div id="desktop-modules-header" class="row">
@@ -434,16 +434,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-left">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>Above-the-Fold Rendering</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>Instead of side rendering the whole page on the server, this react component enables rendering of *only* the components your users see on the screen without scrolling, for improved performance.</br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/above_fold_rendering.html">
                       <img src="/img/icn-atf.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>Above-the-Fold Rendering</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>Instead of side rendering the whole page on the server, this react component enables rendering of *only* the components your users see on the screen without scrolling, for improved performance.</br>
                   </div>
                 </div>
               </div>
@@ -452,16 +452,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-right">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>Redux Router Engine</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>Do you need data from a service to render your component server-side? This module fetches the data asynchronously and passes it to React to render your components. Requires Redux.</br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/redux_router_engine.html">
                       <img src="/img/icn-redux.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>Redux Router Engine</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>Do you need data from a service to render your component server-side? This module fetches the data asynchronously and passes it to React to render your components. Requires Redux.</br>
                   </div>
                   </div>
               </div>
@@ -472,16 +472,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-left">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>Confippet</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>Lets you define, extend, and merge configurations for different environments (such as QA, prod, and staging) that get initialized during start up or at runtime.</br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/confippet.html">
                       <img src="/img/icn-confippet.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>Confippet</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>Lets you define, extend, and merge configurations for different environments (such as QA, prod, and staging) that get initialized during start up or at runtime.</br>
                   </div>
                 </div>
               </div>
@@ -491,16 +491,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-right">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>SSR Profiling & Caching</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>This module can help you improve your React server-side rendering performance by up to 70% by caching your components' render</br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/server_side_render_cache.html">
                       <img src="/img/icn-ssr.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>SSR Profiling & Caching</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>This module can help you improve your React server-side rendering performance by up to 70% by caching your components' render</br>
                   </div>
                 </div>
             </div>
@@ -511,16 +511,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-left">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>Stateless CSRF Validation</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>Validate HTTP requests without a session--for Express and Hapi.</br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/stateless_csrf_validation.html">
                       <img src="/img/icn-csrf.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>Stateless CSRF Validation</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>Validate HTTP requests without a session--for Express and Hapi.</br>
                   </div>
                 </div>
               </div>
@@ -529,16 +529,16 @@
             <div class="module-box">
               <div class="col-sm-6 col-md-6 col-lg-6 desktop-module-text">
                 <div class="row module-testbox module-column-right">
-                  <div class="col-sm-12 col-md-12 module-subheader">
-                    <b>More Modules Coming Soon!</b>
-                  </div>
-                  <div class="col-sm-10 col-md-10 module-textbox">
-                    <br>New module release announcements will be Tweeted on <a href="https://twitter.com/electrode_io">@electrode_io</a></br>
-                  </div>
                   <div class="col-sm-2 col-md-2 desktop-module-logo">
                     <a href="/docs/stand_alone_modules.html">
                       <img src="/img/icn-more.svg" alt="">
                     </a>
+                  </div>
+                  <div class="col-sm-12 col-md-12 col-lg-9 module-subheader">
+                    <b>More Modules Coming Soon!</b>
+                  </div>
+                  <div class="col-sm-12 col-md-10 module-textbox">
+                    <br>New module release announcements will be Tweeted on <a href="https://twitter.com/electrode_io">@electrode_io</a></br>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
- fixed issue: Desktop: Module boxes are same size and seem to be static. Box height should be smaller for modules with less text and scale dynamically.
- The nature of the change is to dynamically resize the height of the boxes for the different breakpoints, where each row will be consistent with the height of the longest text for that row of boxes, essentially less white space. 