### PR TITLE
fix spelling of const components

### DIFF
--- a/_docs/03.1.6-add_examples.markdown
+++ b/_docs/03.1.6-add_examples.markdown
@@ -55,7 +55,7 @@ Navigate to `<your-awesome-component>/demo/examples/your-awesome-component.examp
 />
 ```
 
-Now Navigate to `<your-awesome-component>/demo/demo.jsx`. Modify `const componsnts` to include your demo examples:
+Now Navigate to `<your-awesome-component>/demo/demo.jsx`. Modify `const components` to include your demo examples:
 
 ```javascript
 const components = [


### PR DESCRIPTION
Was just reading over the documentation and noticed a small spelling mistake.