### PR TITLE
Correct name of example file for guest list

### DIFF
--- a/_docs/03.1.4-high_level_component.markdown
+++ b/_docs/03.1.4-high_level_component.markdown
@@ -87,8 +87,12 @@ YourAwesomeComponent.propTypes = {
 };
 
 YourAwesomeComponent.defaultProps = {
-  message: `<p>Let's party! Un-comment the all the commented-out lines in the
-  playground then check the boxes on the GuestList to invite our friends to the party!</p>`
+  ourFriends: [],
+  message: () => {
+    return `<p>Let's party! Un-comment the all the commented-out lines in the
+      playground then check the boxes on the GuestList to invite our friends to the party!</p>`;
+  },
+  invitees: []
 };
 ```
 Last edit! In your `<your-awesome-component>/src/index.js` add the two lines below:

--- a/_docs/03.1.6-add_examples.markdown
+++ b/_docs/03.1.6-add_examples.markdown
@@ -64,7 +64,7 @@ const components = [
     examples: [
       {
         type: "playground",
-        code: require("raw!./examples/house-party.example"),
+        code: require("raw!./examples/guest-list.example"),
         noRender: true
       }
     ]


### PR DESCRIPTION
The previous step calls for creating a .example file named `guest-list.example`, but then instructs one to modify `<your-awesome-component>/demo/demo.jsx` to reference `house-party.example` instead of `guest-list.example`.