### PR TITLE
Updated `production.js` link and value

### DIFF
--- a/_docs/02.5-deploy_app.markdown
+++ b/_docs/02.5-deploy_app.markdown
@@ -140,10 +140,10 @@ Use the command below to set a configuration so that Heroku installs Your-Awesom
 $ heroku config:set NPM_CONFIG_PRODUCTION=false
 ```
 
-Use the command below to set a configuration for [production.js](https://github.com/docs-code-examples-electrode-io/electrode-example-app-with-plugin-and-routes/blob/master/config/production.js#L11):
+Use the command below to set a configuration for [production.js](https://github.com/electrode-io/generator-electrode/blob/master/generators/app/templates/config/production.js#L11):
 
 ```bash
-$ heroku config:set STATIC_FILES=true
+$ heroku config:set STATIC_FILES_OFF=true
 ```
 
 Now deploy your code:


### PR DESCRIPTION
The link to `production.js` is not from a file that is actually included in the tutorial, and it has a different variable name on the highlighted line 11 (and throughout). The file that was previously linked had the value `STATIC_FILES` instead of `STATIC_FILES_OFF`, which will be the case for someone actually following the tutorial.

The `heroku config:set ...` should match the variable that will actually be used, `STATIC_FILES_OFF`.