### PR TITLE
Changed sample app name to be consistent

### DIFF
--- a/_docs/02.3-get_started.markdown
+++ b/_docs/02.3-get_started.markdown
@@ -28,8 +28,8 @@ $ npm install -g yo gulp generator-electrode
 Make a new directory for your awesome app, then [generate](https://github.com/electrode-io/generator-electrode) your new project:
 
 ```bash
-$ mkdir my-electrode-app
-$ cd my-electrode-app
+$ mkdir your-awesome-app
+$ cd your-awesome-app
 $ yo electrode
 ```
 


### PR DESCRIPTION
Changed sample app name from <my-electrode-app> to <your-awesome-app> to be consistent with the the rest of the Quick Start Guide. It someone what confusing that the sample name changes without explanation.