### PR TITLE
Line 28 file path correction to default.json

### DIFF
--- a/_docs/03.4-server_config.markdown
+++ b/_docs/03.4-server_config.markdown
@@ -17,7 +17,7 @@ config
 
 We'll need to extend our default.json to include our `friends` plugin and module `./server/plugins/friends`.
 
-Navigate to `<your-awesome-app>/config/development.json`. Copy, paste and save `friends` plugin below the `webapp` plugin:
+Navigate to `<your-awesome-app>/config/default.json`. Copy, paste and save `friends` plugin below the `webapp` plugin:
 
 ```json
 


### PR DESCRIPTION
the "webapp" plugin is located in 'config/default.json'. 'config/develepment.json' is an empty object. Changed path for inserting 'friends' plugin to 'config/default.json'.