### PR TITLE
Add clarity on when to set STATIC_FILES_OFF

### DIFF
--- a/_docs/02.5-deploy_app.markdown
+++ b/_docs/02.5-deploy_app.markdown
@@ -140,7 +140,7 @@ Use the command below to set a configuration so that Heroku installs Your-Awesom
 $ heroku config:set NPM_CONFIG_PRODUCTION=false
 ```
 
-Use the command below to set a configuration for [production.js](https://github.com/electrode-io/generator-electrode/blob/master/generators/app/templates/config/production.js#L11):
+Use the command below to set a configuration for [production.js](https://github.com/electrode-io/generator-electrode/blob/master/generators/app/templates/config/production.js#L11), only set this if you intend to serve static files with a CDN.
 
 ```bash
 $ heroku config:set STATIC_FILES_OFF=true


### PR DESCRIPTION
I did not closely read through this statement the first time and thought the `STATIC_FILES_OFF` config was required for electrode. I was able to debug and determine why static files weren't working on heroku. I think adding a more direct disclaimer about this config setting will assist future developers from being confused by this.