### PR TITLE
Add instructions to specify npm version.

### DIFF
--- a/_docs/02.5-deploy_app.markdown
+++ b/_docs/02.5-deploy_app.markdown
@@ -33,11 +33,12 @@ Password:
 
 You should see a terminal message `Logged in as your-example-email@your-email-provider.com`. Now, let's deploy!
 
-You'll need to specify the [version of node](https://devcenter.heroku.com/articles/node-best-practices) you are using on your machine into our `package.json`. Add the code below to your `package.json`. Make sure to change `"node": "4.2.x"` to your actual node version. To find out what version you have, run `node -v` in the command line
+You'll need to specify the [version of node](https://devcenter.heroku.com/articles/node-best-practices) and npm you are using on your machine into our `package.json`. Add the code below to your `package.json`. Make sure to change `"node": "4.2.x"`, and `"npm": 3.10.x` to your actual node and npm version. To find out what versions you have, run `node -v` and `npm -v` in the command line
 
 ```json
     "engines": {
-      "node": "4.2.x"
+      "node": "4.2.x",
+      "npm": "3.10.x"
     }
 ```
 


### PR DESCRIPTION
Heroku by default uses npm version 2.x, which will lead to build failures without a clear error message. By specifying the npm version, heroku will use that version and therefore have a successful deploy.