### PR TITLE
Add more information about testing.

### DIFF
--- a/_docs/03.1.5-test_components.markdown
+++ b/_docs/03.1.5-test_components.markdown
@@ -8,6 +8,15 @@ toplevel: "Getting Started: Intermediate"
 
 WalmartLabs believes that testing is critical to writing great, high performance code. This includes unit testing at both the component and application level. For your component, we are using [Mocha] (https://mochajs.org/), a Javascript testing framework that is perfect for running async tests, with [Enzyme] (http://airbnb.io/enzyme/docs/guides/mocha.html), airbnb's awesome testing utility for React, and [chai](http://chaijs.com/) for assertions.
 
+#### How to run tests
+
 ```bash
+# Basic testing and linting
 $ gulp check
+
+# Continous Testing
+## In one terminal
+$ gulp test-frontend-dev-watch
+## In a different terminal
+$ gulp server-test
 ```

--- a/_docs/03.1.5-test_components.markdown
+++ b/_docs/03.1.5-test_components.markdown
@@ -6,7 +6,7 @@ toplevel: "Getting Started: Intermediate"
 
 #### Develop tests for the above components
 
-WalmartLabs believes that testing is critical to writing great, high performance code. This includes unit testing at both the component and application level. For your component, we are using [Mocha] (https://mochajs.org/), a Javascript testing framework that is perfect for running async tests, with [Enzyme] (http://airbnb.io/enzyme/docs/guides/mocha.html), airbnb's awesome testing utility for React.
+WalmartLabs believes that testing is critical to writing great, high performance code. This includes unit testing at both the component and application level. For your component, we are using [Mocha] (https://mochajs.org/), a Javascript testing framework that is perfect for running async tests, with [Enzyme] (http://airbnb.io/enzyme/docs/guides/mocha.html), airbnb's awesome testing utility for React, and [chai](http://chaijs.com/) for assertions.
 
 ```bash
 $ gulp check


### PR DESCRIPTION
This includes the following changes:

- Add a link to chaijs, which is assertion library used.
- Document how to run continuous testing. (note that there is `test-watch-all -------------------   tasks: ["server-test","test-frontend-dev-watch"]`, but it never actually worked on my end. Port 9999 didn't open and neither did chrome).