### PR TITLE
starting server before running tests

### DIFF
--- a/_docs/03.1.5-test_components.markdown
+++ b/_docs/03.1.5-test_components.markdown
@@ -16,7 +16,7 @@ $ gulp check
 
 # Continous Testing
 ## In one terminal
-$ gulp test-frontend-dev-watch
-## In a different terminal
 $ gulp server-test
+## In a different terminal
+$ gulp test-frontend-dev-watch
 ```


### PR DESCRIPTION
Running the `gulp test-frontend-dev-watch` before `gulp server-test` results in test case failure as the server has not started yet.
![screen shot 2016-10-28 at 10 37 36](https://cloud.githubusercontent.com/assets/4782871/19816067/95f65148-9cfa-11e6-8562-b0d96087b7c7.png)

Interchanging the commands results in successful test case run

![screen shot 2016-10-28 at 10 29 25](https://cloud.githubusercontent.com/assets/4782871/19816042/80f954de-9cfa-11e6-8c7e-22896dc100ff.png)

