### PR TITLE
(lint) strings must use doublequote quotes

### DIFF
--- a/_docs/03.2-build_server_plugin.markdown
+++ b/_docs/03.2-build_server_plugin.markdown
@@ -45,7 +45,7 @@ server
 Navigate to `<your-awesome-app>/server/plugins/friends/index.js`. This is where we will make an external API call to Github and request the last ten contributors of our selected Open Source 'friend' using a URL `https://api.github.com/ + /repos/:user/:repo/contributors`. Our GitHub wrapper [library](https://github.com/mikedeboer/node-github) will allow us to use a built in method, `github.repos.getContributors({})`, to streamline this process and return an array of Open Source contributors. We will also use [Bluebird](http://bluebirdjs.com/docs/getting-started.html), a Promise library that makes working with our async API calls much more manageable. Copy, paste and save the code below:
 
 ```javascript
-'use strict';
+"use strict";
 
 //a very simple plugin
 


### PR DESCRIPTION
lint error on `gulp check`
![screen shot 2016-11-02 at 13 27 12](https://cloud.githubusercontent.com/assets/4782871/19946060/172b8c52-a100-11e6-8216-759b84acba8d.png)

after fix 
![screen shot 2016-11-02 at 13 28 09](https://cloud.githubusercontent.com/assets/4782871/19946107/3be272ea-a100-11e6-85a4-ca0cd406417f.png)

