### PR TITLE
Change permalink `bundle-analyzer.html` to `bundle_analyzer.html`

### DIFF
--- a/_docs/04.2-electrode-tools.markdown
+++ b/_docs/04.2-electrode-tools.markdown
@@ -19,6 +19,6 @@ We've created incredible tools for better leverage of your application's capabil
 ![electrode-explorer](/img/electrode-explorer.png)
 
 <br>
-#### [Bundle Analyzer](bundle-analyzer.html) is a webpack tool that gives you a detail list of all the files that went into your deduped and minified bundle JS file.
+#### [Bundle Analyzer](bundle_analyzer.html) is a webpack tool that gives you a detail list of all the files that went into your deduped and minified bundle JS file.
 
 <iframe width="600" height="300" src="https://docs.google.com/spreadsheets/d/1IomT2fYCKEwVY0CO-0jImc7CBj_uAmgy70Egsm4CnVE/edit?usp=sharing&rm=minimal" frameborder="0" allowfullscreen></iframe>

--- a/_docs/04.2.3-bundle_analyzer.markdown
+++ b/_docs/04.2.3-bundle_analyzer.markdown
@@ -1,6 +1,6 @@
 ---
 title:  "Bundle Analyzer"
-permalink: docs/bundle-analyzer.html
+permalink: docs/bundle_analyzer.html
 toplevel: "Stand Alone Modules"
 ---
 


### PR DESCRIPTION
This is to make it consistent with the other pages which use underscores instead of dashes. This also fixes the 404 in `electrode_boilerplate.html`