### PR TITLE
Changed Missleading Title

### DIFF
--- a/_docs/02.4-build_component.markdown
+++ b/_docs/02.4-build_component.markdown
@@ -1,5 +1,5 @@
 ---
-title:  "Build Component"
+title:  "Build a Component"
 permalink: docs/build_component.html
 toplevel: "Getting Started: Quick Guide"
 ---


### PR DESCRIPTION
"Build Component" implies "Build System Component" and not "Building a Component. So added an "a".