### PR TITLE
remove project-name thus path is simpler and general

### DIFF
--- a/_docs/02.4-build_component.markdown
+++ b/_docs/02.4-build_component.markdown
@@ -7,7 +7,7 @@ toplevel: "Getting Started: Quick Guide"
 
 After you've generated your awesome electrode app, you are ready to focus on writing your React components.
 
-Navigate to `<your-awesome-app>/src/client/components/home.jsx`:
+Navigate to `./src/client/components/home.jsx`:
 
 ```javascript
 import React, {PropTypes} from "react";
@@ -66,7 +66,7 @@ const mapDispatchToProps = (dispatch) => {
 export default connect(mapStateToProps, mapDispatchToProps)(Home);
 ```
 
-We'll need a place to keep all of the resources we learned in the [Get Started](get_started.html) section. Let's make a visual library for our present stack and exciting technologies! Copy the code below and paste it into `<your-awesome-app>/src/client/components/home.jsx`:
+We'll need a place to keep all of the resources we learned in the [Get Started](get_started.html) section. Let's make a visual library for our present stack and exciting technologies! Copy the code below and paste it into `./src/client/components/home.jsx`:
 
 ```javascript
 import React, {PropTypes} from "react";
@@ -143,7 +143,7 @@ const mapDispatchToProps = (dispatch) => {
 export default connect(mapStateToProps, mapDispatchToProps)(Home);
 ```
 
-Let's finish the UI by adding styles. Navigate to `<your-awesome-app>/src/client/styles/base.css` and add the code below:
+Let's finish the UI by adding styles. Navigate to `./src/client/styles/base.css` and add the code below:
 
 ```css
 h1 {

--- a/_docs/02.6-whats_inside.markdown
+++ b/_docs/02.6-whats_inside.markdown
@@ -8,17 +8,17 @@ toplevel: "Getting Started: Quick Guide"
 
 What does `generator-electrode` give you? Let's go through the most important files to understand the structure of your new app.
 
-> `<your-awesome-app>/src/client/components/home.jsx`
+> `./src/client/components/home.jsx`
 
 This is the home React component for your app. [React](https://facebook.github.io/react/index.html) is a JavaScript library for building user interfaces. A simplified way to look at React is that it can be used as the _View_ in a _Model-View-Controller_ application. It was created by Facebook and is being actively developed.
 
 Building with React lets developers create a modular and reusable component architecture. We can then reuse the business logic in existing _models_ and _controllers_ because React components encapsulate only the _view_ layer. The components you write are self-contained, which aids developers in quickly determining what a component does directly by reading the source. Finally, it is ideally suited to Universal JavaScript (previously called Isomorphic JavaScript), the practice of sharing code between the server and the client.
 
-> `<your-awesome-app>/src/client/styles/base.css`
+> `./src/client/styles/base.css`
 
 We will use [CSS Modules](https://github.com/css-modules/css-modules): a CSS file in which all class names and animation names are scoped locally by default. At WalmartLabs, this helps us tackle large-scale styling requirements by mitigating the issues inherent in the global scope in CSS.
 
-> `<your-awesome-app>/src/client/app.jsx`
+> `./src/client/app.jsx`
 
 To help you understand what `src/client/app.jsx` is doing, including the relationship between client and server, we've broken down each part of this file with a brief explanation below, including links to sources where you can learn even more:
 
@@ -60,11 +60,11 @@ The rest of the code in `src/client/app.jsx` sets up the React app to run when t
 
 If you have a universal application and server-side rendering, [electrode-redux-router-engine](https://github.com/electrode-io/electrode/tree/master/packages/electrode-redux-router-engine) handles async data for React Server Side Rendering using react-router, Redux, and the Redux Server Rendering pattern.
 
-> `<your-awesome-app>/src/client/routes.jsx`
+> `./src/client/routes.jsx`
 
 We will be sharing our routes between server and client, so obviously we only want to define them in one place. The `src/client/routes.jsx` encapsulates the routing logic accordingly.
 
-> `<your-awesome-app>/config`
+> `./config`
 
 In this folder we are leveraging one of our most important stand alone modules: [Electrode-Confippet](confippet.html). Confippet is a versatile utility for managing your NodeJS application configuration. Its goal is customization and extensibility while offering a [preset configuration](https://github.com/electrode-io/electrode-confippet) out of the box.
 
@@ -79,7 +79,7 @@ config
 
 We use this to keep environment-specific configurations manageable. Once you have your configuration files setup accordingly, you can simply pass the config object to electrode server.
 
-> `<your-awesome-app>/src/server`
+> `./src/server`
 
 {% raw  %}
 ```
@@ -133,11 +133,11 @@ All of your content will be served as an HTML string and placed in this unassumi
 
 This includes React components and Redux. To achieve this, the Electrode team has created another powerful module to optimize performance for an out-of-the-box Universal app: [Electrode-Redux-Router-Engine](https://github.com/electrode-io/electrode-redux-router-engine), which takes React routes and requests and returns HTML to be rendered by `electrode-react-webapp`. We have found this to be the [best tool](https://github.com/electrode-io/electrode-redux-router-engine) for dealing with asynchronous redux actions.
 
-> `<your-awesome-app>/src/client/.babelrc`
+> `./src/client/.babelrc`
 
 This is where we extend our `electrode-archetype-react-app` [Babel](https://babeljs.io/docs/usage/babelrc/) configuration to use [the ES6 presets](https://babeljs.io/docs/plugins/preset-es2015/), as well as specifying any plugins or projects that need additional Babel settings.
 
-> `<your-awesome-app>/.isomorphic-loader-config.json`
+> `./.isomorphic-loader-config.json`
 
 This [powerful tool](https://github.com/electrode-io/isomorphic-loader) makes NodeJS `require` work with files such as images for server-side rendering. It contains three pieces: a Webpack loader, Webpack plugin, and a library for your NodeJS app.
 

--- a/_docs/03.2-build_server_plugin.markdown
+++ b/_docs/03.2-build_server_plugin.markdown
@@ -29,7 +29,7 @@ At their core, plugins are a simple `register object` that has the signature
 `function (server, options, next)`. Read more about building plugins from
 scratch in the [Hapi documentation].
 
-Navigate to the `<your-awesome-app>/src/server/plugins` folder. Make a folder
+Navigate to the `./src/server/plugins` folder. Make a folder
 called `friends`, `cd` into your new `friends` folder, and create an empty
 `index.js` file:
 
@@ -53,7 +53,7 @@ server
 ```
 {% endraw %}
 
-Navigate to `<your-awesome-app>/src/server/plugins/friends/index.js`. This is where
+Navigate to `./src/server/plugins/friends/index.js`. This is where
 we will make an external API call to Github and request the last ten
 contributors of our selected Open Source 'friend' using a URL
 `https://api.github.com/ + /repos/:user/:repo/contributors`. Our GitHub wrapper

--- a/_docs/03.3-add_routes.markdown
+++ b/_docs/03.3-add_routes.markdown
@@ -18,7 +18,7 @@ follow the steps below:
 $ npm i your-awesome-published-npm-module --save
 ```
 
-Navigate to `<your-awesome-app>/src/client/routes.jsx`. Copy, paste and save the
+Navigate to `./src/client/routes.jsx`. Copy, paste and save the
 code below into this file. Change from the literal `YourAwesomeComponent` and
 `your-awesome-node-module` to your actual component name:
 
@@ -36,7 +36,7 @@ export const routes = (
 );
 ```
 
-Navigate to `<your-awesome-app>/src/client/components/home.jsx`. Override the
+Navigate to `./src/client/components/home.jsx`. Override the
 existing code by copying, pasting and saving the code below:
 
 ```javascript

--- a/_docs/03.4-server_config.markdown
+++ b/_docs/03.4-server_config.markdown
@@ -21,7 +21,7 @@ config
 We'll need to extend our default.json to include our `friends` plugin and module
 `./src/server/plugins/friends`.
 
-Navigate to `<your-awesome-app>/config/development.json`. Copy, paste and save
+Navigate to `./config/development.json`. Copy, paste and save
 `friends` plugin:
 
 ```json
@@ -38,7 +38,7 @@ You can learn more about Confippet and ways to extend your config in our
 Advanced Electrode App with the [Confippet] stand alone module.
 
 We should update our app test to reflect the changes we have made. Navigate to
-`<your-awesome-app>/test/client/components/home.spec.jsx`. Override the existing
+`./test/client/components/home.spec.jsx`. Override the existing
 code by copying and pasting the code below:
 
 ```javascript

--- a/_docs/03.7-progressive_web_app.markdown
+++ b/_docs/03.7-progressive_web_app.markdown
@@ -82,7 +82,7 @@ $ yo electrode
 ### Generating a Service Worker
 
 Generating a service worker in an electrode app is as simple as adding a config
-file. Navigate to `<your-awesome-app>/config` and create a new `sw-config.js`:
+file. Navigate to `./config` and create a new `sw-config.js`:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
An alternative would be to name the project `myapp`, but in general the compact `./` makes the tutorial more general (e.g. user can pick any name he prefers).

The "singing tenor" should be usually avoided (see #389). This is not the Broadway.