### PR TITLE
Integrate gitbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ _site
 .jekyll-metadata
 .DS_Store
 
+node_modules
+
 Gemfile.lock
 
 Gemfile.lock

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,5 +4,5 @@ sectionid: docs
 ---
 
 <section class="content documentationContent">
-  <iframe src="https://electrode.gitbooks.io/electrode/" />
+  <iframe src="https://electrode.gitbooks.io/electrode/content" />
 </section>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,19 +3,6 @@ layout: default
 sectionid: docs
 ---
 
-<section class="content wrap documentationContent">
-  {% include nav_docs.html %}
-
-  <div class="inner-content">
-    <a class="edit-page-link" href="https://github.com/electrode-io/electrode-io.github.io/tree/develop/{{ page.path }}" target="_blank">Edit on GitHub</a>
-    <h1>
-      {{ page.title }}
-    </h1>
-    <div class="subHeader">{{ page.description }}</div>
-
-    {{ content }}
-
-    {% include nav_prev_next.html %}
-
-  </div>
+<section class="content documentationContent">
+  <iframe src="https://electrode.gitbooks.io/electrode/" />
 </section>

--- a/css/electrode-docs.scss
+++ b/css/electrode-docs.scss
@@ -31,6 +31,7 @@ $navHeight: 50px;
 
 html {
   background: $pageBg;
+  overflow: hidden;
 }
 
 .left {
@@ -427,6 +428,14 @@ section.black content {
       margin-top: 0;
       text-rendering: optimizelegibility;
     }
+  }
+
+  iframe {
+    width: 100%;
+    height: calc(100% - 97px);
+    position: absolute;
+    top: 97px;
+    bottom: 0;
   }
 }
 


### PR DESCRIPTION
Integrate electrode.io doc site with gitbook (contains search features etc)
Demo:
![screen shot 2017-05-01 at 11 45 24 am](https://cloud.githubusercontent.com/assets/10135897/25592064/19fea686-2e6c-11e7-9fe9-e7c59f2458f6.png)
