### PR TITLE
fix broken links in header for doc pages

### DIFF
--- a/css/electrode.scss
+++ b/css/electrode.scss
@@ -315,6 +315,9 @@ h1 {
       display:none;
     }
   }
+  .contribute-active-margin:before {
+    margin-left: 9.5px !important;
+  }
 }
 
 .navbar-toggle {

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/cauldron.html
+++ b/site/docs/cauldron.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/container.html
+++ b/site/docs/container.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/contribute.html
+++ b/site/docs/contribute.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li id="home-primary" class="contribute-active-margin"><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/getting_started.html
+++ b/site/docs/getting_started.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/introduction.html
+++ b/site/docs/introduction.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>

--- a/site/docs/runner.html
+++ b/site/docs/runner.html
@@ -51,7 +51,7 @@
                 data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
                 <img id="mob-header-icon" class="mob-menu" src="/../img/mob-menu.svg" alt="">
               </button>
-              <a class="navbar-brand electrode-brand-top" href="/site/native.html">
+              <a class="navbar-brand electrode-brand-top" href="/">
                 <img id="walmart-header-logo" class="header-logo" src="/../img/walmartlabs_logo.svg" alt="">
               </a>
             </div>
@@ -72,7 +72,7 @@
                 </a>
               </li>
               <li>
-                <a href="https://github.com/electrode-io">
+                <a href="https://github.com/electrode-io/electrode-native">
                   <img src="/../img/github_@1x.png" alt="">
                 </a>
               </li>
@@ -80,17 +80,17 @@
 
             <ul id="desktop-nav-ul" class="nav navbar-nav navbar-right primary-nav-links mobile-docs-nav">
               <li><a href="/site/native.html">HOME</a></li>
-              <li id="home-primary"><a href="/site/electrode_native_docs.html">DOCS</a></li>
-              <li><a href="/docs/contribute.html">CONTRIBUTE</a></li>
+              <li id="home-primary"><a href="/site/docs/introduction.html">DOCS</a></li>
+              <li><a href="/site/docs/contribute.html">CONTRIBUTE</a></li>
             </ul>
 
             <!-- mobile dropdown menu -->
             <ul id="mobile-nav-ul" class="nav navbar-nav navbar-right secondary-nav-links">
               <li id="home-primary" class="mobile-nav-links"><a href="/site/native.html">Home</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Docs</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/introduction.html">Docs</a></li>
               <div class="mobile-header-line"></div>
-              <li class="mobile-nav-links"><a href="/docs/contribute.html">Contribute</a></li>
+              <li class="mobile-nav-links"><a href="/site/docs/contribute.html">Contribute</a></li>
               <div class="mobile-header-line"></div>
               <li id="mobile-started-link" class="mobile-nav-links"><a href="/site/electrode_native_docs.html">Get Started</a></li>
               <div class="mobile-header-line"></div>
@@ -113,7 +113,7 @@
               </div>
               <div class="col-xs-4 col-sm-4">
                 <div class="mobile-social-header-links mobile-oval">
-                  <a href="https://github.com/electrode-io">
+                  <a href="https://github.com/electrode-io/electrode-native">
                     <img class="mobile-social-logo" src="/../img/sm-github.svg" alt=""/>
                   </a>
                 </div>


### PR DESCRIPTION
- Doc page header links to Walmart logo, contribute, and github icon were linking to electrode web.
- Active link status for contribute link now showing.