### PR TITLE
Fix Electrode Native docs

### DIFF
--- a/css/electrode-docs.scss
+++ b/css/electrode-docs.scss
@@ -1,3 +1,6 @@
+---
+---
+
 @import 'bourbon';
 @import '_variables';
 @import '_typography';

--- a/css/electrode-docs.scss
+++ b/css/electrode-docs.scss
@@ -23,7 +23,7 @@ $navHeight: 50px;
 
 // basic reset
 * {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   border: none;
   margin: 0;
   padding: 0;
@@ -232,7 +232,7 @@ h1, h2, h3, h4, h5, h6 {
         width: 10px;
         height: 10px;
         padding-left: 5px;
-        @include retina-image('../img/external', 10px 10px);
+        background-image: url("/img/external_2x.png");
         background-position: 100% 0;
         background-repeat: no-repeat;
         font-size: 10px;
@@ -316,12 +316,12 @@ h1, h2, h3, h4, h5, h6 {
     }
     input {
       border: 1px solid #ccc;
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, $font-stack-system;
       padding: 3px;
       width: 150px;
     }
     button {
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, $font-stack-system;
       margin-left: 5px;
       padding: 4px 10px;
     }
@@ -330,7 +330,7 @@ h1, h2, h3, h4, h5, h6 {
   #markdownExample {
     textarea {
       border: 1px solid #ccc;
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, $font-stack-system;
       margin-bottom: 10px;
       padding: 5px;
     }
@@ -447,7 +447,7 @@ section.black content {
 /* Button */
 
 .button {
-  @include background(linear-gradient($buttonGreyTop, $buttonGreyBottom));
+  background: linear-gradient($buttonGreyTop, $buttonGreyBottom);
   // border: 1px solid $darkestColor;
   border-radius: 4px;
   padding: 8px 16px;
@@ -479,7 +479,7 @@ section.black content {
 }
 
 .button.blue {
-  @include background(linear-gradient($buttonBlueTop, $buttonBlueBottom));
+  background: linear-gradient($buttonBlueTop, $buttonBlueBottom);
 }
 
 /* Row */

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/platform-parts/apis.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/reference/index-5" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/cauldron.html
+++ b/site/docs/cauldron.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/platform-parts/cauldron.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/reference/index-2" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/container.html
+++ b/site/docs/container.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/platform-parts/container.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/reference/index-1" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/contribute.html
+++ b/site/docs/contribute.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/overview/contributing.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/introduction/what-is-ern/contributing" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/getting_started.html
+++ b/site/docs/getting_started.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/content/getting-started/getting-started.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/introduction.html
+++ b/site/docs/introduction.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/content" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/introduction/what-is-ern" />
     </section>
 
     <footer class="wrap">

--- a/site/docs/runner.html
+++ b/site/docs/runner.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="https://electrode-io.github.io/img/logo_og.png">
   <meta property="og:description" content="Universal React and Node Applications simplified, performant, and reusable.">
   <link rel="shortcut icon" href="/img/favicon-64.png">
-  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">  
+  <link rel="alternate" type="application/rss+xml" title="Electrode" href="http://localhost:4000/feed.xml">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
@@ -130,7 +130,7 @@
     </nav>
 
     <section class="content documentationContent">
-      <iframe id="gitbook-iframe" src="https://electrode.gitbooks.io/electrode-native/platform-parts/runner.html" />
+      <iframe id="gitbook-iframe" src="https://native.electrode.io/reference/index-4" />
     </section>
 
     <footer class="wrap">


### PR DESCRIPTION
Several fixes related to the broken Electrode Native docs as seen below:

1. Revert b3d8fbd - Related to Sass/scss files, [Jekyll docs](https://jekyllrb.com/docs/assets/) state:
   > In order to use them, you must first create a file with the proper extension name (one of .sass, .scss, or .coffee) and start the file with two lines of triple dashes [...]

2. Just adding the two lines back was not enough, since the build will fail due to some deprecated (and no longer supported) syntax in the scss files (addressed by second commit)

3. Finally, updated and fixed several iframe links to GitBooks which were no longer reliably working (simply pointed them to the new location).

![image](https://user-images.githubusercontent.com/743291/98032079-51532400-1dc8-11eb-9ddd-0c206790a920.png)
