### PR TITLE
Add Gemfile.lock and update branches/README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
-_site
-.idea
-.sass-cache
-.jekyll-metadata
 .DS_Store
-
-node_modules
-
-Gemfile.lock
-
-Gemfile.lock
+.idea/
+.jekyll-metadata/
+.sass-cache/
+_site/
+node_modules/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,86 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    bourbon (7.0.0)
+      thor (~> 1.0)
+    colorator (1.1.0)
+    ffi (1.13.1)
+    forwardable-extended (2.6.0)
+    jekyll (3.4.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (1.5.1)
+      listen (~> 3.0)
+    jgd (1.12)
+      jekyll (>= 1.5.1)
+      trollop (= 2.9.9)
+    json (2.3.1)
+    kramdown (1.17.0)
+    liquid (3.0.6)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    mini_portile2 (2.4.0)
+    minima (2.1.1)
+      jekyll (~> 3.3)
+    multi_json (1.15.0)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    pygments.rb (1.2.1)
+      multi_json (>= 1.0.0)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    redcarpet (3.5.0)
+    rouge (1.11.1)
+    safe_yaml (1.0.5)
+    sanitize (2.1.1)
+      nokogiri (>= 1.4.4)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    thor (1.0.1)
+    trollop (2.9.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bourbon
+  jekyll (= 3.4.3)
+  jekyll-paginate
+  jekyll-redirect-from
+  jgd
+  json
+  minima
+  pygments.rb
+  rb-fsevent
+  redcarpet
+  sanitize (~> 2.0)
+
+RUBY VERSION
+   ruby 2.7.1p83
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ is generated using [Jekyll](http://jekyllrb.com/).
 
 ## Contributing
 
-* Commit contributions to the `develop` branch
+* Commit contributions to the `master` branch
 * Use [Markdown](https://daringfireball.net/projects/markdown/) when authoring
   new documentation
 
@@ -41,7 +41,7 @@ The site must be generated locally and deployed using
 > sure you're _**not**_ working in a fork.
 
 First, make sure the `jgd` gem is installed by running `npm run bootstrap`.
-Next, generate and deploy to `master` with the following command:
+Next, generate and deploy to `gh-pages` with the following command:
 
 ```sh
 npm run publish

--- a/README.md
+++ b/README.md
@@ -1,55 +1,53 @@
 # electrode-io.github.io
-This repository contains the source for the Electrode documentation site, which is generated using [Jekyll](http://jekyllrb.com/).
+
+This repository contains the source for the Electrode documentation site, which
+is generated using [Jekyll](http://jekyllrb.com/).
 
 ## Contributing
 
-* Commit contributions to the `develop` branch.
-* Always use [markdown](https://daringfireball.net/projects/markdown/) when authoring new documentation.
-
+* Commit contributions to the `develop` branch
+* Use [Markdown](https://daringfireball.net/projects/markdown/) when authoring
+  new documentation
 
 ## Installation
 
-### Pre-requisites
+### Prerequisites
 
-Requires **jekyll** and **bundler**. You can install them with **gem**:
-
-```bash
-$ gem install jekyll bundler
-```
+* [Ruby](https://www.ruby-lang.org/en/)
+* [Bundler](https://bundler.io/)
 
 ### Setup & Run
 
-First, fork and clone the repository and install the project dependencies using bundler:
+Install the project dependencies using Bundler:
 
-```bash
-$ cd electrode-io.github.io  
-$ npm run bootstrap
+```sh
+npm run bootstrap
 ```
 
 Run the server locally:
 
-```bash
-$ npm start
+```sh
+npm start
 ```
 
-You should be able to access the site at: http://127.0.0.1:4000/
+You should be able to access the site at: [127.0.0.1:4000](http://127.0.0.1:4000/)
 
 ## Deploying to GitHub Pages
 
-The site must be generated locally and deployed using [jgd](http://www.yegor256.com/2014/06/24/jekyll-github-deploy.html).
+The site must be generated locally and deployed using
+[jgd](http://www.yegor256.com/2014/06/24/jekyll-github-deploy.html).
 
-> NOTE: this should be done from a local clone of the **original repo**; make sure you're _**not**_ working in a fork.
+> NOTE: this should be done from a local clone of the **original repo**; make
+> sure you're _**not**_ working in a fork.
 
-First, make sure the `jgd` gem is installed by running `bundle install`.
+First, make sure the `jgd` gem is installed by running `npm run bootstrap`.
 Next, generate and deploy to `master` with the following command:
 
-```bash
-$ git clone git@github.com:electrode-io/electrode-io.github.io.git
-$ cd electrode-io.github.io
-$ npm run bootstrap
-$ npm run publish
+```sh
+npm run publish
 ```
 
 Explore the [Electrode.io](http://www.electrode.io/) Website.
 
-Built with :heart: by [Team Electrode](https://github.com/orgs/electrode-io/people) @WalmartLabs.
+Built with :heart: by [Team Electrode](https://github.com/orgs/electrode-io/people)
+@WalmartLabs.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bootstrap": "bundle install",
     "start": "bundle exec jekyll serve",
-    "publish": "bundle exec jgd --branch=master --branch-from=develop"
+    "publish": "bundle exec jgd"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A couple of quick commits in preparation for future deployments:

- Add `Gemfile.lock` to ensure a reproducible and stable dependency chain over time (the absence of it caused the electrode-native breakage when the site was redeployed for the first time in almost three years in July 2020)
- Minor updates to README.md (all markdownlint fixed)
- Change branches to default (`develop`/`master` to `master`/`gh-pages`)

A new branch `gh-pages` has already been pushed (even with `master`). After this PR is merged, there will be a _one time_ force push from `develop` to `master`, followed by deleting `develop`. Then, we can do the first deployment to `gh-pages` (also already updated in the GitHub Settings dialog).