### PR TITLE
Enable basic GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: ci
+on:
+  push:
+    branches: '*'
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+      - run: bundle install
+      - run: bundle exec jekyll build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # electrode-io.github.io
 
+[![ci][1]][2]
+
 This repository contains the source for the Electrode documentation site, which
 is generated using [Jekyll](http://jekyllrb.com/).
 
@@ -51,3 +53,6 @@ Explore the [Electrode.io](http://www.electrode.io/) Website.
 
 Built with :heart: by [Team Electrode](https://github.com/orgs/electrode-io/people)
 @WalmartLabs.
+
+[1]: https://github.com/electrode-io/electrode-io.github.io/workflows/ci/badge.svg
+[2]: https://github.com/electrode-io/electrode-io.github.io/actions


### PR DESCRIPTION
Very basic CI, running `bundle exec jekyll build`.