### PR TITLE
Enable auto-deploy to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: gh-pages
+on:
+  push:
+    branches: master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+      - run: bundle install
+      - run: bundle exec jekyll build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          commit_message: Deploy
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ gem "jekyll", "3.4.3"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima"
 
-# Supports deployment to GitHub pages with custom Jekyll plugins
-gem 'jgd'
-
 # Jekyll extensions
 gem 'jekyll-redirect-from'
 gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,9 +26,6 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.5.1)
       listen (~> 3.0)
-    jgd (1.12)
-      jekyll (>= 1.5.1)
-      trollop (= 2.9.9)
     json (2.3.1)
     kramdown (1.17.0)
     liquid (3.0.6)
@@ -61,7 +58,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     thor (1.0.1)
-    trollop (2.9.9)
 
 PLATFORMS
   ruby
@@ -71,7 +67,6 @@ DEPENDENCIES
   jekyll (= 3.4.3)
   jekyll-paginate
   jekyll-redirect-from
-  jgd
   json
   minima
   pygments.rb

--- a/README.md
+++ b/README.md
@@ -36,18 +36,8 @@ You should be able to access the site at: [127.0.0.1:4000](http://127.0.0.1:4000
 
 ## Deploying to GitHub Pages
 
-The site must be generated locally and deployed using
-[jgd](http://www.yegor256.com/2014/06/24/jekyll-github-deploy.html).
-
-> NOTE: this should be done from a local clone of the **original repo**; make
-> sure you're _**not**_ working in a fork.
-
-First, make sure the `jgd` gem is installed by running `npm run bootstrap`.
-Next, generate and deploy to `gh-pages` with the following command:
-
-```sh
-npm run publish
-```
+Every push to `master` (i.e. every pull request merged) will automatically
+build and deploy the website to `gh-pages`.
 
 Explore the [Electrode.io](http://www.electrode.io/) Website.
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "bootstrap": "bundle install",
-    "start": "bundle exec jekyll serve",
-    "publish": "bundle exec jgd"
+    "start": "bundle exec jekyll serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With this, every push to `master` will automatically build and deploy the website to `gh-pages`.