### PR TITLE
Remove CNAME and only create on source repo deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,8 +10,14 @@ jobs:
       - uses: actions/setup-ruby@v1
       - run: bundle install
       - run: bundle exec jekyll build
+      - id: cname
+        run: |
+          if [ ${{ github.event.repository.fork }} = 'false' ]; then
+            echo "::set-output name=cname::www.electrode.io"
+          fi
       - uses: peaceiris/actions-gh-pages@v3
         with:
+          cname: ${{ steps.cname.outputs.cname }}
           commit_message: Deploy
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.electrode.io


### PR DESCRIPTION
Remove `CNAME`, and only create this file on automatic deployment in the **source repo**. Having the CNAME hadecoded in the repo root causes deployment failures for `gh-actions` on **forks**. No two repos can share the same CNAME value.

> The CNAME entry can only be used once on GitHub. For example, if another repository's CNAME file contains example.com, you cannot use example.com in the CNAME file for your repository.

https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages#cname-errors