### PR TITLE
Use ruby/setup-ruby for GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 name: ci
 on:
   push:
-    branches: '*'
+    branches: [ '*' ]
   pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-      - run: bundle install
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
       - run: bundle exec jekyll build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,14 +1,16 @@
 name: gh-pages
 on:
   push:
-    branches: master
+    branches: [ master ]
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-      - run: bundle install
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
       - run: bundle exec jekyll build
       - id: cname
         run: |


### PR DESCRIPTION
`setup/setup-ruby` is deprecated and was replaced by `ruby/setup-ruby` see  https://github.com/actions/setup-ruby

Also use fixed ruby version, and bundle install/cache automatically.