### PR TITLE
Remove dependency on bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "minima", "~> 2.5"
 # gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem 'bourbon', "~> 4"
   gem "jekyll-feed", "~> 0.12"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,6 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    bourbon (4.3.4)
-      sass (~> 3.4)
-      thor (~> 0.19)
     colorator (1.1.0)
     concurrent-ruby (1.1.8)
     em-websocket (0.5.2)
@@ -69,18 +66,12 @@ GEM
     rexml (3.2.5)
     rouge (3.26.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc (2.4.0-x64-mingw32)
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.3)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
     tzinfo (1.2.9)
@@ -98,7 +89,6 @@ PLATFORMS
   x86-mswin32
 
 DEPENDENCIES
-  bourbon (~> 4)
   jekyll (~> 4.1.1)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)

--- a/css/electrode-docs.scss
+++ b/css/electrode-docs.scss
@@ -1,7 +1,6 @@
 ---
 ---
 
-@import 'bourbon';
 @import "_variables";
 @import "_typography";
 @import "_solarized";
@@ -321,12 +320,12 @@ h6 {
     }
     input {
       border: 1px solid #ccc;
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, "Helvetica Neue", "Helvetica", "Arial", sans-serif;
       padding: 3px;
       width: 150px;
     }
     button {
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, "Helvetica Neue", "Helvetica", "Arial", sans-serif;
       margin-left: 5px;
       padding: 4px 10px;
     }
@@ -335,7 +334,7 @@ h6 {
   #markdownExample {
     textarea {
       border: 1px solid #ccc;
-      font: 14px proxima-nova, $helvetica;
+      font: 14px proxima-nova, "Helvetica Neue", "Helvetica", "Arial", sans-serif;
       margin-bottom: 10px;
       padding: 5px;
     }

--- a/css/electrode.scss
+++ b/css/electrode.scss
@@ -1,7 +1,6 @@
 ---
 ---
 
-// @import 'bourbon';
 // @import '_variables';
 @import "_typography";
 // @import '_solarized';


### PR DESCRIPTION
I appears the only thing left from bourbon is a single `$helvetica` variable. Replace it with a fixed string, and remove the dependency (this will clear several warnings and remove other no longer needed dependencies as well).