### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-electrode.io


### PR DESCRIPTION
`CNAME` was previously removed in #427, and, as explained in that PR, is created _automatically_ on gh-pages deployment by GitHub Actions (when run in the source repo), see:

https://github.com/electrode-io/electrode-io.github.io/blob/69353b92a91f8f500c5ae32b7197e2b609f167d4/.github/workflows/gh-pages.yml#L15-L22