### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - id: cname
         run: |
           if [ ${{ github.event.repository.fork }} = 'false' ]; then
-            echo "::set-output name=cname::www.electrode.io"
+            echo "cname=www.electrode.io" >> $GITHUB_OUTPUT
           fi
       - uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - id: cname
         run: |
           if [ ${{ github.event.repository.fork }} = 'false' ]; then
-            echo "cname=www.electrode.io" >> $GITHUB_OUTPUT
+            echo "cname=www.electrode.io" >> "$GITHUB_OUTPUT"
           fi
       - uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


